### PR TITLE
xtdb.sql -> xtdb.api

### DIFF
--- a/src/next/jdbc/xt.clj
+++ b/src/next/jdbc/xt.clj
@@ -3,9 +3,9 @@
 (ns next.jdbc.xt
   (:require [clojure.core.reducers :as r]
             [clojure.string :as str]
+            [xtdb.api :as xt]
             [next.jdbc.protocols :as p]
-            [xtdb.node :as xt.node]
-            [xtdb.sql :as xt]))
+            [xtdb.node :as xt.node]))
 
 (extend-protocol p/Sourceable
   xtdb.node.Node


### PR DESCRIPTION
Hey Sean - we've combined `xtdb.sql` and `xtdb.datalog` back into a single `xtdb.api` namespace, can now submit both Datalog and SQL through `xt/q`

James